### PR TITLE
Add sound set support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.6.0
+- **Sound sets**: a portable sonic identity — `{ name, transform, cues }` — loaded with `set({ theme: soundSet })`. A global transform reshapes every cue; per-cue specs replace the ones that matter. `getSet()` snapshots the active identity, JSON-safe and lossless through `set()`. Assigning any named theme clears the whole identity.
+- `getSpec(name)` now returns the *effective* spec (the active set's override, or the built-in) — so the designer, WAV export, board envelopes, and sprite all honor the set.
+- Demo: the designer grew a set workflow — design a cue, "Use site-wide", export the set as JSON, import one, or copy a `#set=` link that carries the entire identity.
+
+
 ## 2.5.0
 - `play()` and `playSpec()` return a handle with `stop()` — each performance runs on its own bus and fades out in ~20ms without touching other sounds.
 - Looping: `play("loading", { loop: true })` repeats until stopped (spacing defaults to the sound's own duration; override with `every`).

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 Foley is a tiny, dependency-free library of **28 interaction sounds**, named for the film artists who perform footsteps and door-latches in sync with the picture. It does the same for your interface: every cue is synthesized with Web Audio at the instant of the action. No audio files, no network requests, no build step.
 
 - **28 cues in 7 families** — pointer, press, toggle, feedback, notify, motion, state
-- **4 themes** — default, soft, mechanical, glass — or pass your own transform object
+- **4 themes** — default, soft, mechanical, glass — or your own transform, or a full [sound set](#sound-sets)
 - **Cues are data** — edit any cue's layers with `getSpec()`/`playSpec()`, or visually in the [Cue Designer](https://usefoley.dev/#designer)
-- **8.4 kB**, zero dependencies, one ES module
+- **9.6 kB**, zero dependencies, one ES module
 - **Defensive by design** — master limiter, 60ms per-cue cooldown, ±30-cent humanization; `stop()` handles, looping, and ducking built in
 - **WAV export** — any cue, any custom design, or all 28 as an audio sprite with an offset map
 
@@ -111,6 +111,30 @@ const wav = await toWavSpec(mySound);
 ```
 
 Or use the visual [Cue Designer on the demo](https://usefoley.dev/#designer) — edit with live playback, then export .wav/.json or share the design as a link.
+
+## Sound sets
+
+A sound set is your product's whole sonic identity as one portable JSON object: a
+global character transform plus full replacement specs for the cues that matter most.
+
+```js
+import { set, getSet } from "@foleyjs/core";
+
+set({ theme: {
+  name: "Acme",
+  transform: { pitch: 0.9, decay: 1.3 },      // every cue, reshaped
+  cues: { success: [/* layers */], error: [/* layers */] }  // these two, replaced
+}});
+
+get().theme;   // "Acme"
+getSet();      // snapshot the active identity - JSON-safe, version it in your repo
+```
+
+- **`getSet()`** returns the active identity; feeding it back through `set({ theme })` is lossless.
+- Assigning any named theme replaces the whole identity, overrides included.
+- Overrides are validated like any spec (unknown cues dropped, params clamped).
+- Build one visually in the [Cue Designer](https://usefoley.dev/#designer): design a cue, pick
+  which built-in it replaces, "Use site-wide", then export the set or copy a set link.
 
 ## Themes
 

--- a/agents.md
+++ b/agents.md
@@ -111,6 +111,11 @@ s.forEach((l) => { l.d *= 1.4; if (l.f) l.f *= 0.84; });  // longer, ~3 st lower
 playSpec(s);
 ```
 
+A whole sonic identity is a **sound set**: `{ name, transform, cues }` — a global
+transform plus per-cue replacement specs. Load with `set({ theme: soundSet })`;
+snapshot with `getSet()`. If the project has a set JSON (often `*-foley-set.json`),
+load it at startup and do not re-tune individual cues by hand.
+
 Humans can do this visually at https://usefoley.dev/#designer — its JSON export is a
 valid spec and can be pasted straight into `playSpec()`, and its share links
 (`#spec=...`) encode the same format. If a user hands you a designer link or JSON

--- a/index.html
+++ b/index.html
@@ -4,9 +4,9 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Foley — sound effects for the interface, performed live</title>
-<meta name="description" content="Foley is a tiny, dependency-free library of 28 interaction sounds — named for the film artists who perform sound in sync with the picture. Every cue is synthesized live with Web Audio at the moment of interaction.">
+<meta name="description" content="Foley is a tiny, dependency-free library of 28 interaction sounds, synthesized live with Web Audio. Design your own cues and ship your product’s sonic identity as a sound set.">
 <meta property="og:title" content="Foley — sound effects for the interface, performed live">
-<meta property="og:description" content="28 interaction sounds synthesized live with Web Audio. Zero dependencies, zero audio files.">
+<meta property="og:description" content="28 interaction sounds synthesized live with Web Audio. Design your own, ship a sound set. Zero dependencies, zero audio files.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://usefoley.dev/">
 <meta property="og:image" content="https://usefoley.dev/assets/og-image.png">
@@ -389,13 +389,16 @@ footer.site{margin-top:90px;border-top:1px solid var(--card-edge);padding:28px 0
 .midi-bar{margin-top:14px;display:flex;align-items:center;gap:12px;flex-wrap:wrap;background:var(--card);border:1px solid var(--card-edge);border-radius:14px;padding:12px 16px}
 .midi-bar label{font-family:var(--mono);font-size:11px;letter-spacing:.12em;text-transform:uppercase;color:var(--ink-faint)}
 .midi-bar .btn{padding:8px 13px;font-size:13px}
+.dz-set{margin-top:16px;padding-top:14px;border-top:1px dashed var(--card-edge)}
+.dz-set .dz-row{margin-bottom:10px}
+.dz-set .dz-seed{max-width:150px}
 </style>
 </head>
 <body>
 <header class="top">
   <div class="wrap top-in">
     <a class="logo" href="#"><span class="logo-jack" aria-hidden="true"></span>foley</a>
-    <span class="ver">v2.5.0 · 8.4 kB</span>
+    <span class="ver">v2.6.0 · 9.6 kB</span>
     <div class="head-scope" aria-hidden="true" title="Live output">
       <canvas id="scope"></canvas>
       <span class="head-cue" id="scope-label">idle</span>
@@ -423,7 +426,7 @@ footer.site{margin-top:90px;border-top:1px solid var(--card-edge);padding:28px 0
   <!-- ============ HERO ============ -->
   <section class="hero">
     <h1>Sound effects for the interface, <span class="lit">performed live.</span></h1>
-    <p class="lede">Foley is a tiny, dependency-free library of <strong>28 interaction sounds</strong> — named for the film artists who perform sound in sync with the picture. Every cue is synthesized live with Web Audio the instant you interact. No audio files, no setup.</p>
+    <p class="lede">Foley is a tiny, dependency-free library of <strong>28 interaction sounds</strong> — named for the film artists who perform sound in sync with the picture. Every cue is synthesized live with Web Audio the instant you interact. No audio files, no setup — and when the defaults aren’t yours, redesign them and ship a <strong>sound set</strong>: your product’s whole sonic identity in one small JSON file.</p>
     <div class="hero-pills" aria-hidden="true">
       <button class="hero-pill" data-cue="chime" style="--pc:var(--c-notify);--r:-4deg;--x:8%;--y:6%">chime</button>
       <button class="hero-pill" data-cue="thock" style="--pc:var(--c-press);--r:3deg;--x:52%;--y:0%">thock</button>
@@ -607,7 +610,7 @@ footer.site{margin-top:90px;border-top:1px solid var(--card-edge);padding:28px 0
 
       <div class="demo-card">
         <h3>Slider</h3>
-        <span class="attr">data-foley-slide="glide"</span>
+        <span class="attr">play("tick", { pitch })</span>
         <p>Detent ticks across the track that rise in pitch with the value — the sound of a thumb wheel.</p>
         <div class="demo-stage" style="flex-direction:column;align-items:stretch">
           <input type="range" id="demo-slider" min="0" max="20" value="8" aria-label="Brightness">
@@ -622,7 +625,7 @@ footer.site{margin-top:90px;border-top:1px solid var(--card-edge);padding:28px 0
   <section class="block" id="designer">
     <div class="eyebrow">Cue designer · roll your own</div>
     <h2 class="blk">Not quite your sound? Change it.</h2>
-    <p class="blk-sub">Start from any cue and shape it with four plain dials — no synthesis degree required. Every change plays live, and the header scope traces it. Export a .wav for your assets folder, JSON for <span class="mono">playSpec()</span>, or share the design as a link. The full layer editor is one click away when you want it.</p>
+    <p class="blk-sub">Start from any cue and shape it with four plain dials — no synthesis degree required. Every change plays live, and the header scope traces it. Export a .wav for your assets folder, JSON for <span class="mono">playSpec()</span>, or share the design as a link. The full layer editor is one click away when you want it. And when a design is right, apply it site-wide — build a <b>sound set</b>, export it as JSON, and load it in your app with <span class="mono">set({ theme: mySet })</span>.</p>
 
     <div class="designer">
       <div class="dz-grid">
@@ -657,6 +660,18 @@ footer.site{margin-top:90px;border-top:1px solid var(--card-edge);padding:28px 0
             <button class="btn btn-ghost" id="dz-link">Copy link</button>
             <input type="file" id="dz-file" accept=".json,application/json" hidden>
           </div>
+          <div class="dz-set">
+            <div class="dz-row"><label>Sound set</label><span class="mini-status" id="set-status">no overrides yet</span></div>
+            <div class="dz-actions">
+              <select class="dz-seed" id="set-cue" title="Which cue this design replaces site-wide"></select>
+              <button class="btn btn-ghost" id="set-apply">Use site-wide</button>
+              <button class="btn btn-ghost" id="set-json">⤓ set</button>
+              <button class="btn btn-ghost" id="set-import">Import set</button>
+              <button class="btn btn-ghost" id="set-link">Copy set link</button>
+              <button class="btn btn-ghost" id="set-clear">Clear</button>
+              <input type="file" id="set-file" accept=".json,application/json" hidden>
+            </div>
+          </div>
           <p class="dz-note" id="dz-note">Space replays. Exports honor your transpose, space, and theme — and designs live in the URL, so copy the link to share one.</p>
         </div>
       </div>
@@ -688,17 +703,17 @@ footer.site{margin-top:90px;border-top:1px solid var(--card-edge);padding:28px 0
 &lt;button <span class="at">data-foley-press</span> <span class="at">data-foley-release</span>&gt;Save&lt;/button&gt;
 &lt;a <span class="at">data-foley-hover</span>=<span class="st">"tick"</span>&gt;Docs&lt;/a&gt;
 &lt;button <span class="at">data-foley-toggle</span>&gt;Dark mode&lt;/button&gt;
-&lt;input <span class="at">data-foley-type</span>=<span class="st">"thock"</span>&gt;
-&lt;input type=<span class="st">"range"</span> <span class="at">data-foley-slide</span>&gt;</code></pre>
+&lt;input <span class="at">data-foley-type</span>=<span class="st">"thock"</span>&gt;</code></pre>
           <pre class="code"><button class="copy-btn" data-copy="#code-js">copy</button><code id="code-js"><span class="kw">import</span> { bind, play, set } <span class="kw">from</span> <span class="st">"@foleyjs/core"</span>;
 
 bind();                     <span class="cm">// wires every data-foley-*</span>
 set({ volume: 0.7,          <span class="cm">// 0 – 1</span>
       transpose: 0,         <span class="cm">// semitones, ±12</span>
       space: 0.2,           <span class="cm">// reverb send</span>
-      theme: <span class="st">"glass"</span> });    <span class="cm">// default · soft · mechanical · glass</span>
+      theme: <span class="st">"glass"</span> });    <span class="cm">// a name — or your sound set object</span>
 
 play(<span class="st">"complete"</span>);           <span class="cm">// any of the 28 cues</span>
+set({ theme: brandSet });   <span class="cm">// load your identity — build one in the designer ↓</span>
 play(<span class="st">"tick"</span>, { pitch: 4, volume: 0.3 });
 
 <span class="kw">const</span> wav = <span class="kw">await</span> toWav(<span class="st">"chime"</span>); <span class="cm">// Blob — offline render</span></code></pre>
@@ -736,7 +751,7 @@ app.use(FoleyPlugin, { theme: <span class="st">"soft"</span> });
   <div class="wrap foot-in">
     <span><strong>foley</strong> · MIT licensed · <a href="https://github.com/eakbulut/foley" target="_blank" rel="noopener">GitHub</a> · <a href="agents.md" target="_blank" rel="noopener">agents.md</a> — point your coding agent at it</span>
     <span class="sp"></span>
-    <span>28 cues · 4 themes · 8.4 kB · synthesized live — or designed, then rendered to .wav</span>
+    <span>28 cues · 4 themes · sound sets · 9.6 kB · synthesized live — designed, shared, and rendered to .wav</span>
   </div>
 </footer>
 <script type="module">
@@ -744,7 +759,7 @@ app.use(FoleyPlugin, { theme: <span class="st">"soft"</span> });
    Demo page wiring. Everything sonic comes from the real
    package: this page runs exactly what `npm install foley` ships.
    ============================================================ */
-import { bind, play, set, get, on, unlock, getAnalyser, toWav, toBuffer, cues, families, version, getSpec, playSpec, toWavSpec, toBufferSpec, normalizeSpec, toSprite } from "./src/foley.js";
+import { bind, play, set, get, on, unlock, getAnalyser, toWav, toBuffer, cues, families, version, getSpec, playSpec, toWavSpec, toBufferSpec, normalizeSpec, toSprite, getSet, themes } from "./src/foley.js";
 
 /* page-side state: colors are a design decision, so they live here, not in the library */
 const FAM = {
@@ -1858,6 +1873,83 @@ if (window.matchMedia("(pointer:coarse)").matches) {
       audition();
     }
   });
+
+  /* ---------- sound sets: this design, applied site-wide ---------- */
+  const setCue = document.getElementById("set-cue");
+  const setStatus = document.getElementById("set-status");
+  Object.keys(cues).forEach((n) => {
+    const o = document.createElement("option");
+    o.value = n; o.textContent = "replace: " + n;
+    setCue.appendChild(o);
+  });
+  seedSel.addEventListener("change", () => { if (seedSel.value) setCue.value = seedSel.value; });
+
+  function refreshSetUI() {
+    const st = getSet();
+    const names = Object.keys(st.cues);
+    setStatus.textContent = names.length
+      ? names.length + " override" + (names.length > 1 ? "s" : "") + ": " + names.slice(0, 4).join(", ") + (names.length > 4 ? "\u2026" : "")
+      : "no overrides yet";
+    const cur = get().theme;
+    const seg = document.getElementById("theme-seg");
+    const themeOut = document.getElementById("o-theme");
+    seg.querySelectorAll("button").forEach((b) => b.setAttribute("aria-pressed", String(b.dataset.theme === cur)));
+    themeOut.textContent = themes.includes(cur) ? cur[0].toUpperCase() + cur.slice(1) : cur;
+    drawEnvelopes(); /* the board honors overrides - keep its envelopes honest */
+    const keep = names.length > 0 || !themes.includes(cur);
+    store.save({ soundSet: keep ? st : null });
+  }
+
+  document.getElementById("set-apply").addEventListener("click", () => {
+    const merged = getSet();
+    if (themes.includes(merged.name)) merged.name = "custom set"; /* a modified identity is no longer the preset */
+    merged.cues[setCue.value] = current();
+    set({ theme: merged });
+    play(setCue.value);
+    refreshSetUI();
+  });
+  document.getElementById("set-json").addEventListener("click", () => {
+    const st = getSet();
+    const fname = (st.name || "foley").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") + "-foley-set.json";
+    saveBlob(new Blob([JSON.stringify(st, null, 2)], { type: "application/json" }), fname);
+  });
+  const setFile = document.getElementById("set-file");
+  document.getElementById("set-import").addEventListener("click", () => setFile.click());
+  setFile.addEventListener("change", () => {
+    const f = setFile.files[0];
+    if (!f) return;
+    const r = new FileReader();
+    r.onload = () => {
+      try { set({ theme: JSON.parse(r.result) }); play("switch"); refreshSetUI(); }
+      catch (e) { play("error"); }
+      setFile.value = "";
+    };
+    r.readAsText(f);
+  });
+  document.getElementById("set-link").addEventListener("click", () => {
+    const b64 = btoa(unescape(encodeURIComponent(JSON.stringify(getSet()))));
+    const url = location.origin + location.pathname + "#set=" + b64;
+    history.replaceState(null, "", "#set=" + b64);
+    navigator.clipboard.writeText(url).then(() => {
+      play("success");
+      setStatus.textContent = "set link copied \u2014 it carries the whole identity";
+    }).catch(() => play("error"));
+  });
+  document.getElementById("set-clear").addEventListener("click", () => {
+    set({ theme: "default" });
+    play("off");
+    refreshSetUI();
+  });
+  /* named-theme clicks in the inspector clear overrides in the engine - mirror it here */
+  document.getElementById("theme-seg").addEventListener("click", () => setTimeout(refreshSetUI, 0));
+
+  /* restore the identity: URL #set= wins, then the saved one */
+  if (location.hash.startsWith("#set=")) {
+    try { set({ theme: JSON.parse(decodeURIComponent(escape(atob(location.hash.slice(5))))) }); } catch (e) { /* bad hash */ }
+  } else if (saved.soundSet) {
+    try { set({ theme: saved.soundSet }); } catch (e) { /* stale */ }
+  }
+  setTimeout(refreshSetUI, 0);
 
   /* initial state: URL hash > saved design > the "on" cue */
   let initial = null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foleyjs/core",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Sound effects for the interface, performed live. 28 interaction cues synthesized with Web Audio \u2014 zero dependencies, zero audio files.",
   "type": "module",
   "main": "./src/foley.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foleyjs/react",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "React bindings for Foley \u2014 sound effects for the interface, performed live.",
   "type": "module",
   "main": "./src/index.js",
@@ -18,7 +18,7 @@
   ],
   "sideEffects": false,
   "peerDependencies": {
-    "@foleyjs/core": "^2.5.0",
+    "@foleyjs/core": "^2.6.0",
     "react": ">=17"
   },
   "publishConfig": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foleyjs/vue",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Vue 3 bindings for Foley \u2014 sound effects for the interface, performed live.",
   "type": "module",
   "main": "./src/index.js",
@@ -18,7 +18,7 @@
   ],
   "sideEffects": false,
   "peerDependencies": {
-    "@foleyjs/core": "^2.5.0",
+    "@foleyjs/core": "^2.6.0",
     "vue": ">=3"
   },
   "publishConfig": {

--- a/src/foley.d.ts
+++ b/src/foley.d.ts
@@ -31,6 +31,17 @@ export interface ThemeTransform {
   wave?: Partial<Record<WaveName, WaveName>> | null;
 }
 
+/** A portable sonic identity: a global transform plus per-cue spec overrides.
+    Load one with set({ theme: soundSet }); snapshot the current one with getSet(). */
+export interface SoundSet {
+  /** Display name; becomes get().theme. */
+  name?: string;
+  /** Global character transform applied to every cue. */
+  transform?: ThemeTransform;
+  /** Full replacement specs for individual cues. */
+  cues?: Partial<Record<CueName, Spec>>;
+}
+
 export interface PlayHandle {
   /** Fade this performance out (~20ms) and, if looping, stop the loop. */
   stop(): void;
@@ -86,7 +97,7 @@ export declare function bind(root?: ParentNode): void;
 
 /** Update engine settings. Only the provided keys change.
     theme accepts a name or a custom ThemeTransform object. */
-export declare function set(opts: Partial<Omit<Settings, "theme">> & { theme?: ThemeName | ThemeTransform }): void;
+export declare function set(opts: Partial<Omit<Settings, "theme">> & { theme?: ThemeName | ThemeTransform | SoundSet }): void;
 
 /** A snapshot of the current settings. */
 export declare function get(): Settings;
@@ -121,8 +132,11 @@ export interface PlaySpecOptions extends PlayOptions {
   id?: string;
 }
 
-/** A deep, editable copy of a built-in cue's spec. */
+/** A deep, editable copy of the cue's effective spec (the active sound set's override, or the built-in). */
 export declare function getSpec(name: CueName): Spec;
+
+/** Snapshot the active sonic identity as a portable SoundSet. */
+export declare function getSet(): SoundSet;
 
 /** Validate and clamp a spec into a safe, playable copy (max 8 layers). */
 export declare function normalizeSpec(spec: unknown): Spec;

--- a/src/foley.js
+++ b/src/foley.js
@@ -5,7 +5,7 @@
    https://github.com/eakbulut/foley
    ============================================================ */
 
-export const version = "2.5.0";
+export const version = "2.6.0";
 
 /* ---------------- engine ---------------- */
 const T = {
@@ -106,6 +106,20 @@ const THEMES = {
                         noiseLvl: 0.45, noiseF: 1.9, q: 3.2, shimmer: true }),
 };
 let theme = THEMES.default;
+let overrides = {}; /* per-cue spec overrides from the active sound set */
+
+function effectiveSpec(name) { return overrides[name] || CUES[name].spec; }
+
+function sanitizeTransform(c) {
+  const lim = (v, lo, hi, fb) => { const n = Number(v); return isFinite(n) ? Math.min(hi, Math.max(lo, n)) : fb; };
+  return {
+    label: "Custom",
+    pitch: lim(c.pitch, 0.25, 4, 1), attack: lim(c.attack, 0.1, 6, 1), decay: lim(c.decay, 0.1, 6, 1),
+    send: lim(c.send, 0, 3, 1), noiseLvl: lim(c.noiseLvl, 0, 3, 1), noiseF: lim(c.noiseF, 0.25, 4, 1),
+    q: lim(c.q, 0.1, 6, 1), shimmer: !!c.shimmer,
+    wave: (c.wave && typeof c.wave === "object") ? c.wave : null,
+  };
+}
 
 export const themes = Object.freeze(Object.keys(THEMES));
 
@@ -413,11 +427,29 @@ export function normalizeSpec(spec) {
   return out;
 }
 
-/** A deep copy of a built-in cue's spec, ready to edit. */
+/** A deep, editable copy of the cue's effective spec - the sound set's override
+    if one is active, the built-in otherwise. */
 export function getSpec(name) {
   const cue = CUES[name];
   if (!cue) return null;
-  return JSON.parse(JSON.stringify(cue.spec));
+  return JSON.parse(JSON.stringify(effectiveSpec(name)));
+}
+
+/** A snapshot of the active sonic identity as a portable sound set:
+    { name, transform, cues }. Feed it back through set({ theme: soundSet }). */
+export function getSet() {
+  const base = mkTheme({});
+  const tr = {};
+  for (const k of ["pitch", "attack", "decay", "send", "noiseLvl", "noiseF", "q"]) {
+    if (theme[k] !== base[k]) tr[k] = theme[k];
+  }
+  if (theme.shimmer) tr.shimmer = true;
+  if (theme.wave) tr.wave = Object.assign({}, theme.wave);
+  return {
+    name: T.settings.theme,
+    transform: tr,
+    cues: JSON.parse(JSON.stringify(overrides)),
+  };
 }
 
 /* ---------------- public API ---------------- */
@@ -442,19 +474,25 @@ export function set(opts) {
   if (opts.hover != null) T.settings.hover = opts.hover;
   if (opts.theme != null) {
     if (typeof opts.theme === "string" && THEMES[opts.theme]) {
+      /* a theme assignment replaces the whole sonic identity, overrides included */
       T.settings.theme = opts.theme;
       theme = THEMES[opts.theme];
-    } else if (typeof opts.theme === "object") {
-      /* custom theme: a partial transform object; unknown fields ignored, values clamped */
-      const c = opts.theme, lim = (v, lo, hi, fb) => { const n = Number(v); return isFinite(n) ? Math.min(hi, Math.max(lo, n)) : fb; };
-      theme = mkTheme({
-        label: "Custom",
-        pitch: lim(c.pitch, 0.25, 4, 1), attack: lim(c.attack, 0.1, 6, 1), decay: lim(c.decay, 0.1, 6, 1),
-        send: lim(c.send, 0, 3, 1), noiseLvl: lim(c.noiseLvl, 0, 3, 1), noiseF: lim(c.noiseF, 0.25, 4, 1),
-        q: lim(c.q, 0.1, 6, 1), shimmer: !!c.shimmer,
-        wave: (c.wave && typeof c.wave === "object") ? c.wave : null,
-      });
-      T.settings.theme = "custom";
+      overrides = {};
+    } else if (typeof opts.theme === "object" && opts.theme) {
+      const o = opts.theme;
+      const isSet = ("cues" in o) || ("transform" in o) || ("name" in o);
+      theme = mkTheme(sanitizeTransform(isSet ? (o.transform || {}) : o));
+      overrides = {};
+      if (isSet && o.cues && typeof o.cues === "object") {
+        for (const [n, sp] of Object.entries(o.cues)) {
+          if (!CUES[n]) continue;           /* unknown cue names are dropped */
+          const norm = normalizeSpec(sp);
+          if (norm.length) overrides[n] = norm;
+        }
+      }
+      T.settings.theme = (isSet && typeof o.name === "string" && o.name.trim())
+        ? String(o.name).trim().slice(0, 40)
+        : "custom";
     }
   }
 }
@@ -529,7 +567,7 @@ function perform(key, spec, opts, emitName, emitFamily) {
 export function play(name, opts) {
   const cue = CUES[name];
   if (!cue) return;
-  return perform(name, cue.spec, opts, name, cue.cat);
+  return perform(name, effectiveSpec(name), opts, name, cue.cat);
 }
 
 /** Play a custom spec (array of layers). It is normalized/clamped first.
@@ -611,7 +649,7 @@ function renderSpecOffline(spec) {
 export async function toBuffer(name) {
   const cue = CUES[name];
   if (!cue) return null;
-  return renderSpecOffline(cue.spec);
+  return renderSpecOffline(effectiveSpec(name));
 }
 
 /** Offline-render a custom spec to an AudioBuffer (normalized first). */
@@ -644,7 +682,7 @@ export async function toSprite(gap) {
   const parts = [], map = {};
   let cursor = 0;
   for (const name of Object.keys(CUES)) {
-    const buf = await renderSpecOffline(CUES[name].spec);
+    const buf = await renderSpecOffline(effectiveSpec(name));
     const t = trimAndNormalize(buf);
     map[name] = { start: +cursor.toFixed(4), duration: +(t.length / rate).toFixed(4) };
     parts.push(t);

--- a/test/freshness.test.mjs
+++ b/test/freshness.test.mjs
@@ -45,6 +45,15 @@ test("every data-foley-* attribute in bind() is documented in README and agents.
   }
 });
 
+test("the demo never advertises a data-foley-* attribute bind() doesn't implement", () => {
+  const page = readFileSync(join(root, "index.html"), "utf8");
+  const real = new Set([...src.matchAll(/data-foley-(\w+)/g)].map((m) => m[1]));
+  for (const m of page.matchAll(/data-foley-(\w+)/g)) {
+    assert.ok(real.has(m[1]),
+      `demo mentions data-foley-${m[1]} but bind() does not implement it`);
+  }
+});
+
 test("every cue and family name appears in the README", () => {
   for (const name of Object.keys(foley.cues)) {
     assert.ok(readme.includes("`" + name + "`"), `README cue table missing "${name}"`);

--- a/test/sets.test.mjs
+++ b/test/sets.test.mjs
@@ -1,0 +1,67 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { set, get, getSpec, getSet, cues } from "../src/foley.js";
+
+function reset() { set({ theme: "default" }); }
+
+test("a sound set applies per-cue overrides without touching other cues", () => {
+  const custom = getSpec("tick");
+  custom[0].f = 3333;
+  set({ theme: { name: "Acme", cues: { tick: custom } } });
+  assert.equal(getSpec("tick")[0].f, 3333);
+  assert.notEqual(getSpec("pop")[0].f, 3333);
+  assert.equal(get().theme, "Acme");
+  reset();
+});
+
+test("getSet round-trips through set() and returns isolated copies", () => {
+  const custom = getSpec("chime");
+  custom[0].f = 777;
+  set({ theme: { name: "Brand", transform: { pitch: 0.9 }, cues: { chime: custom } } });
+  const snap = getSet();
+  assert.equal(snap.name, "Brand");
+  assert.equal(snap.transform.pitch, 0.9);
+  assert.equal(snap.cues.chime[0].f, 777);
+  snap.cues.chime[0].f = 1; /* mutating the snapshot must not affect the engine */
+  assert.equal(getSpec("chime")[0].f, 777);
+  set({ theme: getSet() }); /* feeding a snapshot back is lossless */
+  assert.equal(get().theme, "Brand");
+  assert.equal(getSpec("chime")[0].f, 777);
+  reset();
+});
+
+test("assigning any named theme clears the whole identity, overrides included", () => {
+  const custom = getSpec("tap");
+  custom[0].f = 999;
+  set({ theme: { cues: { tap: custom } } });
+  assert.equal(getSpec("tap")[0].f, 999);
+  set({ theme: "soft" });
+  assert.notEqual(getSpec("tap")[0].f, 999);
+  assert.equal(Object.keys(getSet().cues).length, 0);
+  reset();
+});
+
+test("legacy plain transform objects still work and carry no overrides", () => {
+  set({ theme: { pitch: 0.8, decay: 1.2 } });
+  assert.equal(get().theme, "custom");
+  assert.equal(Object.keys(getSet().cues).length, 0);
+  assert.equal(getSet().transform.pitch, 0.8);
+  reset();
+});
+
+test("invalid override targets and empty specs are dropped; names are bounded", () => {
+  const ok = getSpec("on");
+  set({ theme: { name: "  " + "x".repeat(80), cues: { on: ok, "not-a-cue": ok, hover: [], press: "garbage" } } });
+  const snap = getSet();
+  assert.deepEqual(Object.keys(snap.cues), ["on"]);
+  assert.ok(get().theme.length <= 40);
+  reset();
+});
+
+test("every override target in a full-coverage set is honored", () => {
+  const all = {};
+  for (const n of Object.keys(cues)) all[n] = getSpec(n);
+  set({ theme: { name: "Everything", cues: all } });
+  assert.equal(Object.keys(getSet().cues).length, 28);
+  reset();
+});


### PR DESCRIPTION
**Sound sets**: a portable sonic identity — `{ name, transform, cues }` — loaded with `set({ theme: soundSet })`. A global transform reshapes every cue; per-cue specs replace the ones that matter. `getSet()` snapshots the active identity, JSON-safe and lossless through `set()`. Assigning any named theme clears the whole identity.