### PR TITLE
Spatial audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.7.0
+- **Spatial audio**: `play()` and `playSpec()` take `pan` (-1..1, stereo) or `pos` ([x, y, z], HRTF with inverse distance) — `pos` wins if both are given. Placement is fixed at the trigger and lives on the performance bus, so a looping cue's repetitions inherit it. The reverb send stays center: rooms don't pan, sources do.
+- **`set({ localize: 0.6 })`**: every `data-foley-*` cue pans to where its element sits on screen, so a toolbar on the right clicks on the right. `panFor(el)` exposes the same derivation for hand-written `play()` calls. Default 0 (centered, unchanged).
+- Deliberately not built, since cues are ~200ms one-shots that are over before anything could move them: listener position/orientation, sound cones, distance attributes, and repositioning through the handle. Offline renders (`toWav`, `toBuffer`, `toSprite`) stay deterministic and centered — position is a property of the performance, not of the sound, the same line humanization draws. A WebXR listener API would be issue-driven, not speculative.
+- Demo: a "Localize cues to their elements" toggle in the inspector, persisted like the other settings.
+
+
 ## 2.6.1
 - npm package keywords for discoverability.
 - Site: analytics, SEO metadata (canonical, structured data, sitemap), tightened copy, quote-card polish, contributor docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **Spatial audio**: `play()` and `playSpec()` take `pan` (-1..1, stereo) or `pos` ([x, y, z], HRTF with inverse distance) — `pos` wins if both are given. Placement is fixed at the trigger and lives on the performance bus, so a looping cue's repetitions inherit it. The reverb send stays center: rooms don't pan, sources do.
 - **`set({ localize: 0.6 })`**: every `data-foley-*` cue pans to where its element sits on screen, so a toolbar on the right clicks on the right. `panFor(el)` exposes the same derivation for hand-written `play()` calls. Default 0 (centered, unchanged).
 - Deliberately not built, since cues are ~200ms one-shots that are over before anything could move them: listener position/orientation, sound cones, distance attributes, and repositioning through the handle. Offline renders (`toWav`, `toBuffer`, `toSprite`) stay deterministic and centered — position is a property of the performance, not of the sound, the same line humanization draws. A WebXR listener API would be issue-driven, not speculative.
+- The `complete` shimmer now stays in key — thanks to launch feedback. Its four grains were random across 2–4.5 kHz and clashed with the C major arpeggio underneath; they are now the same chord two octaves up (C7 E7 G7 C8), which also makes the cue fully deterministic instead of seeded-random.
 - Demo: a "Localize cues to their elements" toggle in the inspector, persisted like the other settings.
 
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Foley is a tiny, dependency-free library of **28 interaction sounds**, named for
 - **28 cues in 7 families** — pointer, press, toggle, feedback, notify, motion, state
 - **4 themes** — default, soft, mechanical, glass — or your own transform, or a full [sound set](#sound-sets)
 - **Cues are data** — edit any cue's layers with `getSpec()`/`playSpec()`, or visually in the [Cue Designer](https://usefoley.dev/#designer)
-- **10.8 kB**, zero dependencies, one ES module
+- **10.9 kB**, zero dependencies, one ES module
 - **Placed in space** — `pan` or 3D `pos` per play, or `set({ localize })` to pan every bound cue to where its element sits on screen
 - **Defensive by design** — master limiter, 60ms per-cue cooldown, ±30-cent humanization; `stop()` handles, looping, and ducking built in
 - **WAV export** — any cue, any custom design, or all 28 as an audio sprite with an offset map

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Foley is a tiny, dependency-free library of **28 interaction sounds**, named for
 - **28 cues in 7 families** — pointer, press, toggle, feedback, notify, motion, state
 - **4 themes** — default, soft, mechanical, glass — or your own transform, or a full [sound set](#sound-sets)
 - **Cues are data** — edit any cue's layers with `getSpec()`/`playSpec()`, or visually in the [Cue Designer](https://usefoley.dev/#designer)
-- **9.6 kB**, zero dependencies, one ES module
+- **10.8 kB**, zero dependencies, one ES module
+- **Placed in space** — `pan` or 3D `pos` per play, or `set({ localize })` to pan every bound cue to where its element sits on screen
 - **Defensive by design** — master limiter, 60ms per-cue cooldown, ±30-cent humanization; `stop()` handles, looping, and ducking built in
 - **WAV export** — any cue, any custom design, or all 28 as an audio sprite with an offset map
 
@@ -79,13 +80,14 @@ Every attribute accepts a cue name as its value to override the default.
 import { play, bind, set, get, toWav, unlock, getAnalyser, on, cues, families, themes, version } from "@foleyjs/core";
 ```
 
-- **`play(name, { pitch?, volume?, loop?, every? })`** — play a cue; returns `{ stop() }`. With `loop: true` it repeats until stopped — ideal for loading states.
+- **`play(name, { pitch?, volume?, loop?, every?, pan?, pos? })`** — play a cue; returns `{ stop() }`. With `loop: true` it repeats until stopped — ideal for loading states.
 - **`bind(root?)`** — wire all `data-foley-*` attributes under `root` (default `document`). Idempotent.
-- **`set({ volume?, transpose?, space?, muted?, hover?, theme?, duck? })`** — update global settings. `duck` (0–1) temporarily attenuates everything, e.g. while a video plays. `theme` accepts a name or a custom transform object (`{ pitch, decay, send, ... }`).
+- **`set({ volume?, transpose?, space?, muted?, hover?, theme?, duck?, localize? })`** — update global settings. `duck` (0–1) temporarily attenuates everything, e.g. while a video plays. `localize` (0–1) pans every bound cue to its element's place on screen. `theme` accepts a name or a custom transform object (`{ pitch, decay, send, ... }`).
+- **`panFor(el)`** — the pan `localize` would derive for an element, for your own `play()` calls.
 - **`get()`** — snapshot of current settings.
 - **`toBuffer(name)`** — `Promise<AudioBuffer>`: same offline render, raw — for envelope drawings, meters, or custom encoding.
 - **`getSpec(name)`** — a deep, editable copy of a built-in cue's layer spec.
-- **`playSpec(spec, { id?, pitch?, volume? })`** — play a custom spec; it is validated and clamped first.
+- **`playSpec(spec, { id?, pitch?, volume?, pan?, pos? })`** — play a custom spec; it is validated and clamped first.
 - **`toWavSpec(spec)` / `toBufferSpec(spec)`** — offline-render a custom spec.
 - **`normalizeSpec(spec)`** — the validator itself, for checking untrusted specs (max 8 layers, all params clamped).
 - **`toSprite(gap?)`** — all 28 cues in one WAV plus a `{ name: { start, duration } }` offset map, for game engines and audio-sprite players.
@@ -94,6 +96,27 @@ import { play, bind, set, get, toWav, unlock, getAnalyser, on, cues, families, t
 - **`getAnalyser()`** — the engine's `AnalyserNode` for scopes and meters, or `null` before unlock.
 - **`on("play" | "unlock", cb)`** — subscribe to engine events; returns an unsubscribe function.
 - **`cues` / `families` / `themes` / `version`** — metadata for building your own pickers and playgrounds.
+
+## Placement
+
+A cue can come from somewhere. `pan` puts it in the stereo field; `pos` puts it in 3D
+(HRTF, inverse distance) for WebXR and canvas scenes.
+
+```js
+play("tick", { pan: -0.7 });              // over on the left
+play("ping", { pos: [2, 0, -3] });        // up and to the right, a few metres out
+set({ localize: 0.6 });                   // every bound cue pans to its own button
+```
+
+One setting and the interface stops sounding like it comes from a single point — a
+toolbar on the right clicks on the right, which is the thing a screen-shaped sound
+library can do that a game audio engine never bothered to.
+
+Placement is fixed at the trigger: cues are ~200ms one-shots, over before anything
+could move, so there is no listener, no cones, and nothing to reposition mid-flight.
+The reverb send stays center — rooms don't pan, sources do. Exports (`toWav`,
+`toSprite`) stay centered too: position is a property of the performance, not of the
+sound, the same rule humanization follows.
 
 ## Design your own cues
 

--- a/agents.md
+++ b/agents.md
@@ -51,6 +51,22 @@ h.stop();          // ~20ms fade; then play("complete")
 set({ duck: 0.3 }); // attenuate everything while a video/call plays; duck: 1 restores
 ```
 
+## Placement
+
+Cues can be positioned. `pan` (-1..1) is stereo, `pos` ([x, y, z]) is 3D (HRTF) for
+WebXR and canvas scenes; both are set at the trigger and never move, because a cue is
+a ~200ms one-shot. There is no listener API and no repositioning — do not look for one.
+
+```js
+play("tick", { pan: -0.7 });         // left side of the screen
+play("ping", { pos: [2, 0, -3] });   // 3D scenes
+set({ localize: 0.6 });              // every data-foley-* cue pans to its own element
+```
+
+Prefer `set({ localize })` over hand-computing pans for DOM UI: `bind()` derives each
+element's position for you. For a `play()` call you make yourself, `panFor(el)` returns
+the same value. Exports (`toWav`, `toSprite`) are always centered.
+
 ## Cue selection guide
 
 - Button press feel: `press` + `release` (two-part), or `tap` (single)

--- a/index.html
+++ b/index.html
@@ -420,7 +420,7 @@ html,body{overflow-x:clip}
 <header class="top">
   <div class="wrap top-in">
     <a class="logo" href="#"><span class="logo-jack" aria-hidden="true"></span>foley</a>
-    <span class="ver">v2.7.0 · 10.8 kB</span>
+    <span class="ver">v2.7.0 · 10.9 kB</span>
     <div class="head-scope" aria-hidden="true" title="Live output">
       <canvas id="scope"></canvas>
       <span class="head-cue" id="scope-label">idle</span>

--- a/index.html
+++ b/index.html
@@ -420,7 +420,7 @@ html,body{overflow-x:clip}
 <header class="top">
   <div class="wrap top-in">
     <a class="logo" href="#"><span class="logo-jack" aria-hidden="true"></span>foley</a>
-    <span class="ver">v2.6.1 · 9.6 kB</span>
+    <span class="ver">v2.7.0 · 10.8 kB</span>
     <div class="head-scope" aria-hidden="true" title="Live output">
       <canvas id="scope"></canvas>
       <span class="head-cue" id="scope-label">idle</span>
@@ -510,6 +510,7 @@ html,body{overflow-x:clip}
         </div>
         <div class="insp-toggles">
           <button class="pill-toggle" id="hover-toggle" aria-pressed="false"><span class="sw" aria-hidden="true"></span>Play cues on hover</button>
+          <button class="pill-toggle" id="localize-toggle" aria-pressed="false"><span class="sw" aria-hidden="true"></span>Localize cues to their elements</button>
           <button class="pill-toggle" id="mute-toggle" aria-pressed="false"><span class="sw" aria-hidden="true"></span>Mute everything</button>
         </div>
       </div>
@@ -782,7 +783,7 @@ app.use(FoleyPlugin, { theme: <span class="st">"soft"</span> });
    Demo page wiring. Everything sonic comes from the real
    package: this page runs exactly what `npm install foley` ships.
    ============================================================ */
-import { bind, play, set, get, on, unlock, getAnalyser, toWav, toBuffer, cues, families, version, getSpec, playSpec, toWavSpec, toBufferSpec, normalizeSpec, toSprite, getSet, themes } from "./src/foley.js";
+import { bind, play, set, get, on, unlock, getAnalyser, toWav, toBuffer, cues, families, version, getSpec, playSpec, toWavSpec, toBufferSpec, normalizeSpec, toSprite, getSet, themes, panFor } from "./src/foley.js";
 
 /* page-side state: colors are a design decision, so they live here, not in the library */
 /* design tokens are CSS custom properties; canvases read them here so a palette
@@ -1093,6 +1094,17 @@ document.addEventListener("keydown", (e) => {
     set({ hover: onNow });
     store.save({ hover: onNow });
     play(onNow ? "on" : "off");
+  });
+  /* localize: cues pan to where their element sits on screen. bind() does the
+     derivation, so the page only owns the on/off. */
+  const loc = document.getElementById("localize-toggle");
+  if (saved.localize) { loc.setAttribute("aria-pressed", "true"); set({ localize: 0.6 }); }
+  loc.addEventListener("click", () => {
+    const onNow = loc.getAttribute("aria-pressed") !== "true";
+    loc.setAttribute("aria-pressed", String(onNow));
+    set({ localize: onNow ? 0.6 : 0 });
+    store.save({ localize: onNow });
+    play(onNow ? "on" : "off", { pan: onNow ? panFor(loc) : 0 });
   });
   const mute = document.getElementById("mute-toggle");
   mute.addEventListener("click", () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "@foleyjs/core",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "dev": true,
   "packages": {
     "": {
       "name": "@foleyjs/core",
-      "version": "2.6.1",
+      "version": "2.7.0",
       "license": "MIT",
       "devDependencies": {
         "@foleyjs/core": "file:.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foleyjs/core",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "Sound effects for the interface, performed live. 28 interaction cues synthesized with Web Audio \u2014 zero dependencies, zero audio files.",
   "type": "module",
   "main": "./src/foley.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foleyjs/react",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "React bindings for Foley \u2014 sound effects for the interface, performed live.",
   "type": "module",
   "main": "./src/index.js",
@@ -18,7 +18,7 @@
   ],
   "sideEffects": false,
   "peerDependencies": {
-    "@foleyjs/core": "^2.6.1",
+    "@foleyjs/core": "^2.7.0",
     "react": ">=17"
   },
   "publishConfig": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foleyjs/vue",
-  "version": "2.6.1",
+  "version": "2.7.0",
   "description": "Vue 3 bindings for Foley \u2014 sound effects for the interface, performed live.",
   "type": "module",
   "main": "./src/index.js",
@@ -18,7 +18,7 @@
   ],
   "sideEffects": false,
   "peerDependencies": {
-    "@foleyjs/core": "^2.6.1",
+    "@foleyjs/core": "^2.7.0",
     "vue": ">=3"
   },
   "publishConfig": {

--- a/src/foley.d.ts
+++ b/src/foley.d.ts
@@ -23,6 +23,11 @@ export interface PlayOptions {
   loop?: boolean;
   /** Loop period in seconds (default: the sound's own duration). */
   every?: number;
+  /** Stereo placement for this play only, -1 (left) to 1 (right). Fixed at trigger. */
+  pan?: number;
+  /** 3D placement for this play only, [x, y, z] (HRTF, inverse distance).
+      Wins over `pan`. Fixed at trigger — cues are one-shots, nothing repositions. */
+  pos?: [number, number, number];
 }
 
 export interface ThemeTransform {
@@ -62,6 +67,9 @@ export interface Settings {
   theme: ThemeName | "custom";
   /** Temporary attenuation multiplier (0-1), e.g. while a video plays. Default 1. */
   duck: number;
+  /** Stereo spread for bind()'s cues, 0–1: each one pans to its element's place
+      on screen. 0 (default) keeps everything centered. */
+  localize: number;
 }
 
 export interface CueMeta {
@@ -92,8 +100,13 @@ export declare const themes: readonly ThemeName[];
     Returns a handle whose stop() fades the performance out. */
 export declare function play(name: CueName, opts?: PlayOptions): PlayHandle | undefined;
 
-/** Wire every data-foley-* attribute under root (default: document). Idempotent. */
+/** Wire every data-foley-* attribute under root (default: document). Idempotent.
+    With a nonzero `localize` setting, each cue pans to its element's screen position. */
 export declare function bind(root?: ParentNode): void;
+
+/** The pan (-1..1) the current `localize` setting derives for an element, or 0 when
+    localize is off. bind() applies it automatically; use it for your own play() calls. */
+export declare function panFor(el: Element | null): number;
 
 /** Update engine settings. Only the provided keys change.
     theme accepts a name or a custom ThemeTransform object. */

--- a/src/foley.js
+++ b/src/foley.js
@@ -5,12 +5,12 @@
    https://github.com/eakbulut/foley
    ============================================================ */
 
-export const version = "2.6.1";
+export const version = "2.7.0";
 
 /* ---------------- engine ---------------- */
 const T = {
   ctx: null, master: null, limiter: null, analyser: null, dry: null, verb: null, wet: null,
-  settings: { volume: 0.7, transpose: 0, space: 0.22, muted: false, hover: true, theme: "default", duck: 1 },
+  settings: { volume: 0.7, transpose: 0, space: 0.22, muted: false, hover: true, theme: "default", duck: 1, localize: 0 },
   _scale: 1, _cool: {}, _noise: null, _unlocked: false, _bus: null, _sendBus: null,
 
   applyGain() {
@@ -460,9 +460,11 @@ export function unlock() { T.ensure(); }
 /** The engine's AnalyserNode (2048-point), or null before the first unlock. For scopes and meters. */
 export function getAnalyser() { return T.analyser; }
 
-/** Update engine settings: volume (0-1), transpose (semitones), space (0-1 reverb), muted, hover, theme. */
+/** Update engine settings: volume (0-1), transpose (semitones), space (0-1 reverb),
+    muted, hover, theme, duck (0-1), localize (0-1 stereo spread for bind()'s cues). */
 export function set(opts) {
   if (!opts) return;
+  if (opts.localize != null) T.settings.localize = Math.min(1, Math.max(0, Number(opts.localize) || 0));
   if (opts.volume != null) { T.settings.volume = opts.volume; T.applyGain(); }
   if (opts.duck != null) { T.settings.duck = Math.min(1, Math.max(0, opts.duck)); T.applyGain(); }
   if (opts.space != null) {
@@ -513,6 +515,36 @@ function specDuration(spec) {
   return end;
 }
 
+/* ---------------- spatial placement ----------------
+   A cue is a ~200ms one-shot: it is over long before anything could move. So
+   position is a play option, fixed at the moment of the trigger, and not a
+   property of the sound. Deliberately absent, and not an oversight: listener
+   position/orientation, cones, distance attributes, repositioning through the
+   handle, and panned exports. Those exist to serve long-running sources; here
+   they would be surface with nothing behind it. A WebXR listener API, if it is
+   ever wanted, is an issue-driven follow-up. */
+
+function clampPan(v) {
+  const n = Number(v);
+  return isFinite(n) ? Math.min(1, Math.max(-1, n)) : 0;
+}
+
+function validPos(p) {
+  if (!Array.isArray(p) || p.length !== 3) return null;
+  const xyz = p.map(Number);
+  return xyz.every((n) => isFinite(n)) ? xyz : null;
+}
+
+/** The pan (-1..1) that the current `localize` setting derives for an element from
+    where it sits horizontally on screen; 0 when localize is 0. bind() applies this
+    to every data-foley-* cue - use it when you call play() yourself. */
+export function panFor(el) {
+  const lz = T.settings.localize;
+  if (!lz || !el || typeof el.getBoundingClientRect !== "function") return 0;
+  const r = el.getBoundingClientRect();
+  return clampPan(((r.left + r.width / 2) / window.innerWidth * 2 - 1) * lz);
+}
+
 /* shared performance path: cooldown, humanization, loop, stop handle, emit */
 function perform(key, spec, opts, emitName, emitFamily) {
   const nowMs = performance.now();
@@ -522,7 +554,27 @@ function perform(key, spec, opts, emitName, emitFamily) {
   opts = opts || {};
   const ctx = T.ctx;
   /* every performance gets its own bus, so it can be stopped without touching the rest */
-  const bus = ctx.createGain(); bus.connect(T.dry);
+  const bus = ctx.createGain();
+  /* placement sits on the bus, not on the voices, so a looping cue's repetitions
+     - which re-run through this same bus - inherit it without rescheduling. */
+  const xyz = validPos(opts.pos);
+  const pan = xyz ? 0 : clampPan(opts.pan);
+  let place = null;
+  if (xyz) {
+    place = ctx.createPanner();
+    place.panningModel = "HRTF";
+    place.distanceModel = "inverse";
+    place.refDistance = 1;
+    place.rolloffFactor = 1;
+    if (place.positionX) { place.positionX.value = xyz[0]; place.positionY.value = xyz[1]; place.positionZ.value = xyz[2]; }
+    else place.setPosition(xyz[0], xyz[1], xyz[2]); /* older Safari */
+  } else if (pan) {
+    place = ctx.createStereoPanner();
+    place.pan.value = pan;
+  }
+  if (place) { bus.connect(place); place.connect(T.dry); } else bus.connect(T.dry);
+  /* the reverb send stays center and unpanned on purpose: rooms don't pan, sources
+     do. A tail that swings with the source reads as the walls moving, not the button. */
   const sendBus = ctx.createGain(); sendBus.connect(T.verb);
 
   function once() {
@@ -556,14 +608,16 @@ function perform(key, spec, opts, emitName, emitFamily) {
       const t = ctx.currentTime;
       bus.gain.setTargetAtTime(0, t, 0.02);
       sendBus.gain.setTargetAtTime(0, t, 0.02);
-      setTimeout(() => { try { bus.disconnect(); sendBus.disconnect(); } catch (e) { /* already gone */ } }, 300);
+      setTimeout(() => { try { bus.disconnect(); sendBus.disconnect(); if (place) place.disconnect(); } catch (e) { /* already gone */ } }, 300);
     },
   };
 }
 
-/** Play a cue by name. Options: { pitch, volume, loop, every }.
+/** Play a cue by name. Options: { pitch, volume, loop, every, pan, pos }.
     Returns a handle: { stop() }. With loop: true the cue repeats (spaced by its own
-    duration, or opts.every seconds) until stopped - for loading states. */
+    duration, or opts.every seconds) until stopped - for loading states.
+    pan (-1..1) places it in the stereo field; pos ([x,y,z]) places it in 3D and
+    wins over pan. Both are fixed for the life of the performance. */
 export function play(name, opts) {
   const cue = CUES[name];
   if (!cue) return;
@@ -571,7 +625,7 @@ export function play(name, opts) {
 }
 
 /** Play a custom spec (array of layers). It is normalized/clamped first.
-    Options: { pitch, volume, id } - id keys the 60ms cooldown (default "custom"). */
+    Options: { pitch, volume, pan, pos, id } - id keys the 60ms cooldown (default "custom"). */
 export function playSpec(spec, opts) {
   const s = normalizeSpec(spec);
   if (!s.length) return;
@@ -580,37 +634,38 @@ export function playSpec(spec, opts) {
 }
 
 /** Wire every data-foley-* attribute under root (default: document).
-    Attributes: data-foley-hover, -press, -release, -click, -toggle, -type. Safe to call again. */
+    Attributes: data-foley-hover, -press, -release, -click, -toggle, -type. Safe to call again.
+    With set({ localize }) nonzero, every cue is panned to its element's place on screen. */
 export function bind(root) {
   root = root || document;
   root.querySelectorAll("[data-foley-hover]").forEach((el) => {
     if (el._fyH) return; el._fyH = 1;
-    el.addEventListener("pointerenter", () => { if (T.settings.hover) play(el.getAttribute("data-foley-hover") || "tick"); });
+    el.addEventListener("pointerenter", () => { if (T.settings.hover) play(el.getAttribute("data-foley-hover") || "tick", { pan: panFor(el) }); });
   });
   root.querySelectorAll("[data-foley-press]").forEach((el) => {
     if (el._fyP) return; el._fyP = 1;
-    el.addEventListener("pointerdown", () => play(el.getAttribute("data-foley-press") || "press"));
+    el.addEventListener("pointerdown", () => play(el.getAttribute("data-foley-press") || "press", { pan: panFor(el) }));
   });
   root.querySelectorAll("[data-foley-release]").forEach((el) => {
     if (el._fyR) return; el._fyR = 1;
-    el.addEventListener("pointerup", () => play(el.getAttribute("data-foley-release") || "release"));
+    el.addEventListener("pointerup", () => play(el.getAttribute("data-foley-release") || "release", { pan: panFor(el) }));
   });
   root.querySelectorAll("[data-foley-click]").forEach((el) => {
     if (el._fyC) return; el._fyC = 1;
-    el.addEventListener("click", () => play(el.getAttribute("data-foley-click") || "tap"));
+    el.addEventListener("click", () => play(el.getAttribute("data-foley-click") || "tap", { pan: panFor(el) }));
   });
   root.querySelectorAll("[data-foley-toggle]").forEach((el) => {
     if (el._fyT) return; el._fyT = 1;
     el.addEventListener("click", () => {
       const pressed = el.getAttribute("aria-pressed") === "true";
-      play(pressed ? "on" : "off");
+      play(pressed ? "on" : "off", { pan: panFor(el) });
     });
   });
   root.querySelectorAll("[data-foley-type]").forEach((el) => {
     if (el._fyY) return; el._fyY = 1;
     el.addEventListener("keydown", (e) => {
-      if (e.key === "Enter") { play("complete"); return; }
-      if (e.key.length === 1 || e.key === "Backspace") play(el.getAttribute("data-foley-type") || "thock", { pitch: (Math.random() * 2 - 1) });
+      if (e.key === "Enter") { play("complete", { pan: panFor(el) }); return; }
+      if (e.key.length === 1 || e.key === "Backspace") play(el.getAttribute("data-foley-type") || "thock", { pitch: (Math.random() * 2 - 1), pan: panFor(el) });
     });
   });
   /* first gesture anywhere unlocks audio */

--- a/src/foley.js
+++ b/src/foley.js
@@ -335,7 +335,12 @@ const CUES = {
     L("tone", 0.08, { wave: "sine", f: 659.25, f2: null, glide: 0.06, a: 0.004, d: 0.21, peak: 0.12, send: 0.3 }),
     L("tone", 0.16, { wave: "sine", f: 783.99, f2: null, glide: 0.06, a: 0.004, d: 0.26, peak: 0.12, send: 0.3 }),
     L("tone", 0.24, { wave: "sine", f: 1046.5, f2: null, glide: 0.06, a: 0.004, d: 0.31, peak: 0.12, send: 0.3 }),
-    L("cluster", 0.34, { n: 4, step: 0.03, fMin: 2000, fMax: 4500, d: 0.09, peak: 0.03, send: 0.5, seed: 7 }),
+    /* the shimmer is the arpeggio's own chord, two octaves up - C7 E7 G7 C8.
+       Random grains across 2-4.5k clashed with the C major underneath them. */
+    L("tone", 0.34, { wave: "sine", f: 2093, f2: null, glide: 0.06, a: 0.004, d: 0.09, peak: 0.03, send: 0.5 }),
+    L("tone", 0.37, { wave: "sine", f: 2637, f2: null, glide: 0.06, a: 0.004, d: 0.09, peak: 0.03, send: 0.5 }),
+    L("tone", 0.40, { wave: "sine", f: 3135.96, f2: null, glide: 0.06, a: 0.004, d: 0.09, peak: 0.03, send: 0.5 }),
+    L("tone", 0.43, { wave: "sine", f: 4186, f2: null, glide: 0.06, a: 0.004, d: 0.09, peak: 0.03, send: 0.5 }),
   ]},
   sparkle:  { cat: "state", key: "K", ds: "a handful of glitter", spec: [
     L("cluster", 0, { n: 6, step: 0.035, fMin: 1600, fMax: 4600, d: 0.1, peak: 0.045, send: 0.5, seed: 11 }),

--- a/test/designer.test.mjs
+++ b/test/designer.test.mjs
@@ -35,11 +35,15 @@ test("converted specs preserve the original synthesis parameters (spot checks)",
   assert.equal(chime.length, 4);
   assert.ok(Math.abs(chime[1].f - 880 * 2.76) < 0.01, "bell partial ratio lost");
 
+  /* the shimmer is chord-locked (2.7.0): the last four layers are C7 E7 G7 C8,
+     the arpeggio's own triad two octaves up, not random grains across the band */
   const complete = getSpec("complete");
-  const cluster = complete[complete.length - 1];
-  assert.equal(cluster.kind, "cluster");
-  assert.equal(cluster.n, 4);
-  assert.equal(cluster.seed, 7, "shimmer must be seeded for deterministic exports");
+  assert.equal(complete.length, 8);
+  const shimmer = complete.slice(-4);
+  assert.deepEqual(shimmer.map((l) => l.kind), ["tone", "tone", "tone", "tone"]);
+  assert.deepEqual(shimmer.map((l) => l.f), [2093, 2637, 3135.96, 4186]);
+  assert.deepEqual(shimmer.map((l) => l.at), [0.34, 0.37, 0.4, 0.43]);
+  for (const l of shimmer) assert.equal(l.peak, 0.03, "shimmer stays a quiet halo over the arpeggio");
 
   const swoosh = getSpec("swoosh");
   assert.equal(swoosh[0].f2, 3400);

--- a/test/spatial.test.mjs
+++ b/test/spatial.test.mjs
@@ -1,0 +1,107 @@
+/* Spatial audio (2.7.0). The engine paths need an AudioContext, but the pan
+   derivation and the clamping are pure - so they are extracted and tested here,
+   alongside the usual enumerate-reality doc guards. */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import * as foley from "../src/foley.js";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const read = (p) => readFileSync(join(root, p), "utf8");
+
+/* panFor reads window.innerWidth; node has no window, so stand one up */
+globalThis.window = Object.assign(globalThis.window || {}, { innerWidth: 1000 });
+const elAt = (left, width) => ({ getBoundingClientRect: () => ({ left, width }) });
+
+test("panFor is 0 while localize is off, wherever the element is", () => {
+  foley.set({ localize: 0 });
+  assert.equal(foley.panFor(elAt(0, 100)), 0);
+  assert.equal(foley.panFor(elAt(980, 20)), 0);
+});
+
+test("panFor derives the pan from horizontal position, scaled by localize", () => {
+  foley.set({ localize: 1 });
+  assert.equal(foley.panFor(elAt(450, 100)), 0, "a centered element stays center");
+  assert.equal(foley.panFor(elAt(0, 0)), -1, "left edge is hard left");
+  assert.equal(foley.panFor(elAt(1000, 0)), 1, "right edge is hard right");
+  foley.set({ localize: 0.6 });
+  assert.equal(foley.panFor(elAt(0, 0)), -0.6, "localize scales the spread");
+  assert.equal(foley.panFor(elAt(750, 0)), 0.3);
+});
+
+test("panFor clamps off-screen elements and survives junk", () => {
+  foley.set({ localize: 1 });
+  assert.equal(foley.panFor(elAt(-9000, 0)), -1, "scrolled-off-left must not exceed -1");
+  assert.equal(foley.panFor(elAt(9000, 0)), 1, "scrolled-off-right must not exceed 1");
+  assert.equal(foley.panFor(null), 0);
+  assert.equal(foley.panFor({}), 0, "a non-element is center, not a crash");
+  foley.set({ localize: 0 });
+});
+
+test("localize is clamped to 0..1 and reported by get()", () => {
+  foley.set({ localize: 0.6 });
+  assert.equal(foley.get().localize, 0.6);
+  foley.set({ localize: 9 });
+  assert.equal(foley.get().localize, 1, "localize must clamp to 0..1");
+  foley.set({ localize: -3 });
+  assert.equal(foley.get().localize, 0);
+  foley.set({ localize: "sideways" });
+  assert.equal(foley.get().localize, 0, "non-numeric localize falls back to center");
+  foley.set({ localize: 0 });
+});
+
+test("play accepts pan and pos without an AudioContext to fail into", () => {
+  /* no context in node: the guard is that option handling never throws before it */
+  assert.doesNotThrow(() => foley.play("not-a-cue", { pan: 0.5 }));
+  assert.doesNotThrow(() => foley.play("not-a-cue", { pos: [1, 2, 3] }));
+  assert.equal(foley.playSpec([], { pan: 2 }), undefined);
+});
+
+/* ---------- docs enumerate reality ---------- */
+
+test("every settings key is documented in the README and the d.ts Settings interface", () => {
+  const dts = read("src/foley.d.ts"), readme = read("README.md");
+  const iface = dts.match(/export interface Settings \{([\s\S]*?)\n\}/);
+  assert.ok(iface, "Settings interface not found in d.ts");
+  for (const k of Object.keys(foley.get())) {
+    assert.ok(new RegExp("\\b" + k + "\\??:").test(iface[1]), `d.ts Settings is missing "${k}"`);
+    assert.ok(readme.includes(k + "?") || readme.includes("`" + k + "`"),
+      `README never documents the "${k}" setting`);
+  }
+});
+
+test("every play option in the d.ts is documented in the README's play() signature", () => {
+  const dts = read("src/foley.d.ts");
+  const m = dts.match(/export interface PlayOptions \{([\s\S]*?)\n\}/);
+  assert.ok(m, "PlayOptions not found in d.ts");
+  const keys = [...m[1].matchAll(/^\s*(\w+)\?:/gm)].map((x) => x[1]);
+  for (const required of ["pan", "pos"]) {
+    assert.ok(keys.includes(required), `PlayOptions must declare "${required}"`);
+  }
+  const sig = read("README.md").match(/\*\*`play\(name, \{([^}]*)\}\)`\*\*/);
+  assert.ok(sig, "README play() signature not found");
+  for (const k of keys) assert.ok(sig[1].includes(k + "?"), `README play() signature missing ${k}?`);
+});
+
+test("agents.md covers placement, since agents will be asked for it", () => {
+  const agents = read("agents.md");
+  for (const t of ["pan", "pos", "localize", "panFor"]) {
+    assert.ok(agents.includes(t), `agents.md missing ${t}`);
+  }
+});
+
+test("demo exposes localize and persists it through the store adapter", () => {
+  const page = read("index.html");
+  assert.ok(page.includes('id="localize-toggle"'), "demo missing the localize toggle");
+  assert.ok(page.includes("store.save({ localize"), "localize must persist like the other settings");
+  assert.ok(page.includes('class="pill-toggle" id="localize-toggle"'),
+    "the toggle must reuse the existing pill-toggle chrome, not invent new controls");
+});
+
+test("the reverb send stays center: rooms don't pan, sources do", () => {
+  const src = read("src/foley.js");
+  assert.ok(/const sendBus = ctx\.createGain\(\); sendBus\.connect\(T\.verb\);/.test(src),
+    "the send bus must connect straight to the reverb, with no panner in between");
+});


### PR DESCRIPTION
### **Spatial placement**

The design insight, after reading Howler's 659-line plugin: Howler spatializes long-running sources, so it needs live repositioning, a movable listener, cones, and getter/setter machinery. Foley's cues are ~200ms one-shots, so position is just a play option, fixed at trigger time:

- play(name, { pan }) / playSpec(spec, { pan }) — StereoPannerNode on the per-performance bus, clamped -1..1.

- { pos: [x, y, z] } — PannerNode (HRTF, inverse distance model), wins over pan. Legacy setPosition fallback for older Safari.

- set({ localize: 0.6 }) — the UI-native feature Howler doesn't have: every bind() cue pans to its element's horizontal position on screen. panFor(el) is exported for custom calls. Demo gets a Localize toggle in the inspector, persisted.

- Placement lives on the bus, not the voices, so looping cues inherit it across repetitions for free.
