### PR TITLE
bind() delegates, and hover fires on keyboard focus

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Browsers require a user gesture before audio can start; `bind()` installs a one-
 
 | Attribute | Fires on | Default cue |
 | --- | --- | --- |
-| `data-foley-hover` | `pointerenter` | `tick` |
+| `data-foley-hover` | `pointerenter`, `focusin` | `tick` |
 | `data-foley-press` | `pointerdown` | `press` |
 | `data-foley-release` | `pointerup` | `release` |
 | `data-foley-click` | `click` | `tap` |
@@ -61,6 +61,11 @@ Browsers require a user gesture before audio can start; `bind()` installs a one-
 | `data-foley-type` | `keydown` (Enter plays `complete`) | `thock` |
 
 Every attribute accepts a cue name as its value to override the default.
+
+`bind()` delegates from `root`, so it covers elements that don't exist yet — render a
+modal, change routes, append a list item, and they all sound without re-binding. Hover
+also fires on keyboard focus, so tabbing through an interface sounds like moving
+through it.
 
 ## The 28 cues
 
@@ -81,7 +86,7 @@ import { play, bind, set, get, toWav, unlock, getAnalyser, on, cues, families, t
 ```
 
 - **`play(name, { pitch?, volume?, loop?, every?, pan?, pos? })`** — play a cue; returns `{ stop() }`. With `loop: true` it repeats until stopped — ideal for loading states.
-- **`bind(root?)`** — wire all `data-foley-*` attributes under `root` (default `document`). Idempotent.
+- **`bind(root?)`** — wire all `data-foley-*` attributes under `root` (default `document`). Idempotent, and delegated: markup rendered later is covered without re-binding.
 - **`set({ volume?, transpose?, space?, muted?, hover?, theme?, duck?, localize? })`** — update global settings. `duck` (0–1) temporarily attenuates everything, e.g. while a video plays. `localize` (0–1) pans every bound cue to its element's place on screen. `theme` accepts a name or a custom transform object (`{ pitch, decay, send, ... }`).
 - **`panFor(el)`** — the pan `localize` would derive for an element, for your own `play()` calls.
 - **`get()`** — snapshot of current settings.

--- a/agents.md
+++ b/agents.md
@@ -29,7 +29,7 @@ attributes already cover.
 | `data-foley-press` + `data-foley-release` | pointerdown / pointerup | press / release |
 | `data-foley-click` | click | tap |
 | `data-foley-toggle` | click (reads `aria-pressed`) | on / off |
-| `data-foley-hover` | pointerenter | tick |
+| `data-foley-hover` | pointerenter + keyboard focus | tick |
 | `data-foley-type` | keydown (Enter → complete) | thock |
 
 Any attribute takes a cue name as its value: `data-foley-click="success"`.
@@ -84,7 +84,9 @@ the same value. Exports (`toWav`, `toSprite`) are always centered.
 
 ## Rules
 
-1. Call `bind()` exactly once (it is idempotent, but once is the pattern).
+1. Call `bind()` exactly once, at startup. It delegates, so markup rendered later
+   (modals, routes, list items) is already covered — do NOT re-bind after renders,
+   and do not add your own listeners for attributes bind() handles.
 2. Never gate `play()` behind your own throttling — the engine has a 60ms
    per-cue cooldown and a master limiter built in.
 3. Do not preload, fetch, or bundle sound files for these cues; they are synthesized.

--- a/packages/react/src/index.js
+++ b/packages/react/src/index.js
@@ -8,8 +8,8 @@ import { bind, play, set, get, toWav, toBuffer, on } from "@foleyjs/core";
  *   const { play, set } = useFoley({ volume: 0.7, theme: "soft" });
  *   <button onClick={() => play("success")}>Save</button>
  *
- * bind() is idempotent, so StrictMode's double-invoke is harmless. For markup
- * rendered after mount, call bind() again (e.g. in that component's effect).
+ * bind() is idempotent, so StrictMode's double-invoke is harmless. It also delegates,
+ * so markup rendered after mount is covered - no re-binding on every render.
  */
 export function useFoley(options) {
   useEffect(() => {

--- a/src/foley.d.ts
+++ b/src/foley.d.ts
@@ -101,7 +101,9 @@ export declare const themes: readonly ThemeName[];
 export declare function play(name: CueName, opts?: PlayOptions): PlayHandle | undefined;
 
 /** Wire every data-foley-* attribute under root (default: document). Idempotent.
-    With a nonzero `localize` setting, each cue pans to its element's screen position. */
+    Delegated: markup added after this call — modals, routes, list items — is covered
+    too, so one call at startup is enough. `data-foley-hover` also fires on keyboard
+    focus. With a nonzero `localize` setting, each cue pans to its screen position. */
 export declare function bind(root?: ParentNode): void;
 
 /** The pan (-1..1) the current `localize` setting derives for an element, or 0 when

--- a/src/foley.js
+++ b/src/foley.js
@@ -640,39 +640,63 @@ export function playSpec(spec, opts) {
 
 /** Wire every data-foley-* attribute under root (default: document).
     Attributes: data-foley-hover, -press, -release, -click, -toggle, -type. Safe to call again.
+    Delegated, so markup added later - modals, routes, list items - is covered too:
+    call this once at startup and never think about it again.
     With set({ localize }) nonzero, every cue is panned to its element's place on screen. */
 export function bind(root) {
   root = root || document;
-  root.querySelectorAll("[data-foley-hover]").forEach((el) => {
-    if (el._fyH) return; el._fyH = 1;
-    el.addEventListener("pointerenter", () => { if (T.settings.hover) play(el.getAttribute("data-foley-hover") || "tick", { pan: panFor(el) }); });
+  /* one delegated listener set per root. Binding both a subtree and the document
+     would double-fire, but the 60ms cooldown swallows the duplicate. */
+  if (root._fyBound) return;
+  root._fyBound = 1;
+
+  /* the nearest ancestor of the event target carrying this attribute, if any.
+     Attribute names stay literal here so the docs guards can enumerate them. */
+  const hit = (e, sel) => (e.target && e.target.closest) ? e.target.closest(sel) : null;
+  const at = (el, attr, fallback, opts) =>
+    play(el.getAttribute(attr) || fallback, Object.assign({ pan: panFor(el) }, opts));
+
+  root.addEventListener("pointerdown", (e) => {
+    const el = hit(e, "[data-foley-press]");
+    if (el) at(el, "data-foley-press", "press");
   });
-  root.querySelectorAll("[data-foley-press]").forEach((el) => {
-    if (el._fyP) return; el._fyP = 1;
-    el.addEventListener("pointerdown", () => play(el.getAttribute("data-foley-press") || "press", { pan: panFor(el) }));
+  root.addEventListener("pointerup", (e) => {
+    const el = hit(e, "[data-foley-release]");
+    if (el) at(el, "data-foley-release", "release");
   });
-  root.querySelectorAll("[data-foley-release]").forEach((el) => {
-    if (el._fyR) return; el._fyR = 1;
-    el.addEventListener("pointerup", () => play(el.getAttribute("data-foley-release") || "release", { pan: panFor(el) }));
+  root.addEventListener("click", (e) => {
+    const c = hit(e, "[data-foley-click]");
+    if (c) at(c, "data-foley-click", "tap");
+    const t = hit(e, "[data-foley-toggle]");   /* an element may carry both; both should sound */
+    if (t) play(t.getAttribute("aria-pressed") === "true" ? "on" : "off", { pan: panFor(t) });
   });
-  root.querySelectorAll("[data-foley-click]").forEach((el) => {
-    if (el._fyC) return; el._fyC = 1;
-    el.addEventListener("click", () => play(el.getAttribute("data-foley-click") || "tap", { pan: panFor(el) }));
+  root.addEventListener("keydown", (e) => {
+    const el = hit(e, "[data-foley-type]");
+    if (!el) return;
+    if (e.key === "Enter") { play("complete", { pan: panFor(el) }); return; }
+    if (e.key.length === 1 || e.key === "Backspace") at(el, "data-foley-type", "thock", { pitch: (Math.random() * 2 - 1) });
   });
-  root.querySelectorAll("[data-foley-toggle]").forEach((el) => {
-    if (el._fyT) return; el._fyT = 1;
-    el.addEventListener("click", () => {
-      const pressed = el.getAttribute("aria-pressed") === "true";
-      play(pressed ? "on" : "off", { pan: panFor(el) });
-    });
+
+  /* hover is the one event that resists delegation: pointerenter doesn't bubble, so
+     we listen to pointerover and fire only when the matched element actually changes
+     - sliding across a button's own children must stay silent. pointerout clears the
+     latch only when the pointer leaves the element entirely, not for a child. */
+  let hovered = null;
+  root.addEventListener("pointerover", (e) => {
+    const el = hit(e, "[data-foley-hover]");
+    if (el === hovered) return;
+    hovered = el;
+    if (el && T.settings.hover) at(el, "data-foley-hover", "tick");
   });
-  root.querySelectorAll("[data-foley-type]").forEach((el) => {
-    if (el._fyY) return; el._fyY = 1;
-    el.addEventListener("keydown", (e) => {
-      if (e.key === "Enter") { play("complete", { pan: panFor(el) }); return; }
-      if (e.key.length === 1 || e.key === "Backspace") play(el.getAttribute("data-foley-type") || "thock", { pitch: (Math.random() * 2 - 1), pan: panFor(el) });
-    });
+  root.addEventListener("pointerout", (e) => {
+    if (hovered && !hovered.contains(e.relatedTarget)) hovered = null;
   });
+  /* keyboard users get the same cue: focusin bubbles where focus does not */
+  root.addEventListener("focusin", (e) => {
+    const el = hit(e, "[data-foley-hover]");
+    if (el && T.settings.hover) at(el, "data-foley-hover", "tick");
+  });
+
   /* first gesture anywhere unlocks audio */
   ["pointerdown", "keydown"].forEach((ev) =>
     document.addEventListener(ev, () => T.ensure(), { once: true, capture: true })

--- a/test/bind.test.mjs
+++ b/test/bind.test.mjs
@@ -1,0 +1,66 @@
+/* bind() delegation guards. There is no DOM in node and no test dependencies here,
+   so these assert the shape of bind() itself; the behavior is verified in a browser.
+   The failure they exist to catch: bind() walking the DOM once, which leaves every
+   element rendered after startup silent. */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const read = (p) => readFileSync(join(root, p), "utf8");
+const src = read("src/foley.js");
+const bindBody = src.match(/export function bind\(root\) \{[\s\S]*?\n\}/);
+
+test("bind() exists and is extractable for these guards", () => {
+  assert.ok(bindBody, "bind(root) not found in src/foley.js");
+});
+
+test("bind() delegates instead of walking the DOM once", () => {
+  const body = bindBody[0];
+  assert.ok(!/querySelectorAll/.test(body),
+    "bind() must delegate from root, not querySelectorAll at call time - " +
+    "markup rendered after startup would be silent");
+  assert.ok(!/_fy[HPRCTY]\b/.test(body),
+    "per-element _fy* flags mean per-element listeners; delegation needs neither");
+  assert.ok(/closest\(/.test(body), "delegation resolves targets with closest()");
+});
+
+test("every data-foley-* attribute still has a delegated handler", () => {
+  const body = bindBody[0];
+  for (const attr of ["hover", "press", "release", "click", "toggle", "type"]) {
+    assert.ok(body.includes("[data-foley-" + attr + "]"),
+      `bind() lost its handler for data-foley-${attr}`);
+  }
+});
+
+test("bind() is idempotent, so a second call cannot double-wire a root", () => {
+  const body = bindBody[0];
+  assert.ok(/_fyBound/.test(body), "bind() must no-op on a root it already delegates from");
+});
+
+test("hover survives delegation: pointerover latched, pointerout released", () => {
+  const body = bindBody[0];
+  /* pointerenter does not bubble, so hover must be built from pointerover plus a
+     latch - otherwise sliding across a button's children re-fires the cue. */
+  assert.ok(body.includes("pointerover"), "hover must delegate via pointerover");
+  assert.ok(body.includes("pointerout"), "the hover latch must be released on pointerout");
+  assert.ok(/relatedTarget/.test(body),
+    "pointerout must ignore moves into a child, or re-entry re-fires");
+});
+
+test("keyboard users get the hover cue too", () => {
+  assert.ok(bindBody[0].includes("focusin"),
+    "data-foley-hover must also fire on focus, or keyboard users hear nothing " +
+    "that mouse users hear");
+});
+
+test("the docs stopped telling people to re-bind after render", () => {
+  const react = read("packages/react/src/index.js");
+  assert.ok(!/call bind\(\) again/.test(react),
+    "the React package still documents the re-bind workaround that delegation removes");
+  for (const [file, text] of [["README.md", read("README.md")], ["agents.md", read("agents.md")]]) {
+    assert.ok(/delegat/i.test(text), `${file} should explain that bind() delegates`);
+  }
+});


### PR DESCRIPTION
## The problem

`bind()` walked `querySelectorAll` once and stamped `_fyH`…`_fyY` flags on each element. Anything rendered *after* that call — a modal, a route change, a list item — was silent until someone re-bound. `packages/react/src/index.js` documented the workaround:

> For markup rendered after mount, call bind() again (e.g. in that component's effect).

In a component framework, markup appearing after mount is the normal case. So the default experience in both framework packages was quietly broken, in the way users don't report — they just conclude the library is flaky.

## The change

One delegated listener set per root, resolving targets with `closest()`. Markup that doesn't exist yet is covered. Six `querySelectorAll` loops and the `_fy*` expandos written onto user DOM nodes are gone.

**Hover needed care.** `pointerenter` doesn't bubble, so it's rebuilt from `pointerover` plus a latch that `pointerout` clears only when the pointer leaves the element entirely — sliding across a button's own children stays silent, exactly as before.

**`focusin` added**, gated by the existing `hover` setting. Keyboard users now get the cue mouse users already had; `focusin` bubbles where `focus` does not.

## Notes for review

- Attribute names are kept **literal** in the source, because `freshness.test.mjs` enumerates them by grepping `src/foley.js`. Building selectors by concatenation would have silently defeated that guard.
- Binding both a subtree and the document would double-fire; the existing 60ms cooldown swallows the duplicate. `_fyBound` makes a repeat `bind(sameRoot)` a no-op.
- No version bump or CHANGELOG entry here, deliberately — see below.

## Verification

7 new guards (80 tests green), plus behavior verified in Chrome, since node has no DOM and this repo has no test dependencies:

| case | result |
|---|---|
| late-added markup, all six attributes | fires |
| move onto a child of a hover element | silent |
| out-into-child, then re-enter | silent |
| genuine leave, then re-enter | fires |
| `focusin` | fires |
| `set({ hover: false })` | silences both paths |
| `bind()` called twice | fires exactly once |

No console errors. `node --check` on the page module, `npm test`, `npm run build` all green.

## Version

Intentionally **no version bump**: this and the hidden-tab PR would both touch the same seven sync points and conflict. Bump once to 2.8.0 with a combined CHANGELOG entry after both land.