### PR TITLE
Looping cues fall silent in a hidden tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ set({ theme: "glass" }); // "default" | "soft" | "mechanical" | "glass"
 - A **master limiter** (DynamicsCompressor as brick-wall safety) so overlapping cues never clip.
 - A **60ms per-cue cooldown** so hover storms and fast sliders stay musical instead of machine-gunning.
 - **Humanization**: each performance drifts up to ±30 cents in pitch and ±8% in level, applied to the whole cue at once — repeated ticks sound performed, not stamped.
+- **Looping cues fall silent in a background tab** and resume when it's visible again, so a forgotten `play("loading", { loop: true })` can't serenade someone from a tab they've left. One-shots still fire — a `ping` for an incoming message is the point.
 
 ## Framework packages
 

--- a/agents.md
+++ b/agents.md
@@ -48,6 +48,8 @@ play("complete");  // a long task finishing
 const h = play("loading", { loop: true }); // repeats until stopped
 await work();
 h.stop();          // ~20ms fade; then play("complete")
+                   // loops go quiet while the tab is hidden, and resume on return -
+                   // you do not need a visibilitychange listener for this
 set({ duck: 0.3 }); // attenuate everything while a video/call plays; duck: 1 restores
 ```
 

--- a/src/foley.js
+++ b/src/foley.js
@@ -550,6 +550,15 @@ export function panFor(el) {
   return clampPan(((r.left + r.width / 2) / window.innerWidth * 2 - 1) * lz);
 }
 
+/* A loop in a backgrounded tab is noise from a page the user can't see, and an
+   AudioContext is not reliably suspended there - so repetitions are skipped while the
+   tab is hidden. One-shots are deliberately left alone: a ping for an incoming message
+   is exactly what a background tab should still be allowed to do. setInterval keeps
+   running either way, so the loop simply picks up again when the tab comes back. */
+function loopAudible() {
+  return !T.settings.muted && !(typeof document !== "undefined" && document.hidden);
+}
+
 /* shared performance path: cooldown, humanization, loop, stop handle, emit */
 function perform(key, spec, opts, emitName, emitFamily) {
   const nowMs = performance.now();
@@ -600,7 +609,7 @@ function perform(key, spec, opts, emitName, emitFamily) {
   let iv = null;
   if (opts.loop) {
     const period = ((opts.every != null ? opts.every : specDuration(spec)) + 0.06) * 1000;
-    iv = setInterval(() => { if (!T.settings.muted) once(); }, Math.max(80, period));
+    iv = setInterval(() => { if (loopAudible()) once(); }, Math.max(80, period));
   }
   emit("play", { name: emitName, family: emitFamily });
 

--- a/test/background.test.mjs
+++ b/test/background.test.mjs
@@ -1,0 +1,42 @@
+/* Background-tab silence for looping cues. The gate itself needs an AudioContext and
+   a real document.hidden, so behavior is verified in a browser; these guards pin the
+   two decisions that are easy to undo by accident. */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const read = (p) => readFileSync(join(root, p), "utf8");
+const src = read("src/foley.js");
+
+test("loop repetitions are gated on tab visibility, not just mute", () => {
+  const gate = src.match(/function loopAudible\(\)[\s\S]*?\n\}/);
+  assert.ok(gate, "loopAudible() not found");
+  assert.ok(/document\.hidden/.test(gate[0]), "the gate must consult document.hidden");
+  assert.ok(/T\.settings\.muted/.test(gate[0]), "the gate must still honor mute");
+  assert.ok(/typeof document/.test(gate[0]),
+    "guard the document reference - the module is imported in node by this very suite");
+});
+
+test("the loop interval actually uses the gate", () => {
+  assert.ok(/setInterval\(\(\) => \{ if \(loopAudible\(\)\) once\(\); \}/.test(src),
+    "the loop must call loopAudible(), or the gate is dead code");
+});
+
+test("one-shots are NOT gated: a background ping is the whole point of a ping", () => {
+  /* only the loop's setInterval may consult the gate; the initial once() must not */
+  const perform = src.match(/function perform\([\s\S]*?\n\}\n/);
+  assert.ok(perform, "perform() not found");
+  const beforeLoop = perform[0].slice(0, perform[0].indexOf("if (opts.loop)"));
+  assert.ok(!/loopAudible/.test(beforeLoop),
+    "the first performance must fire regardless of visibility");
+});
+
+test("the behavior is documented where users and agents will look", () => {
+  assert.ok(/background tab/i.test(read("README.md")),
+    "README must mention background-tab silence");
+  assert.ok(/hidden/i.test(read("agents.md")),
+    "agents.md must say loops go quiet while hidden, so agents stop hand-rolling it");
+});


### PR DESCRIPTION
## The problem

An `AudioContext` is not reliably suspended in a background tab. So a `play("loading", { loop: true })` that outlives its task — or just a slow request while the user tabs away — keeps ticking at someone from a page they are no longer looking at. There is no way for them to tell which tab it is coming from.

## The change

One gate on the loop's `setInterval`:

```js
function loopAudible() {
  return !T.settings.muted && !(typeof document !== "undefined" && document.hidden);
}
```

**One-shots are deliberately not gated.** A `ping` for an incoming message is precisely what a backgrounded tab *should* still be able to do; silencing those would break notifications. Only repetitions are suppressed.

`setInterval` keeps running either way, so the loop resumes when the tab comes back — no restart logic, and no `visibilitychange` listener for callers to wire up. That last part is why it belongs in the library rather than in every app.

The `typeof document` guard is load-bearing: this module is imported directly by the node test suite.

## Verification

4 new guards (77 tests green), plus behavior verified in Chrome with `document.hidden` overridden. Counting real oscillator creation rather than `play` events — worth noting that loop repetitions don't emit `play`, which is why the obvious counter reads zero:

| case | oscillators |
|---|---|
| loop, tab visible | 2 |
| loop, tab hidden | **0** |
| one-shot while hidden | 4 (fires, as intended) |
| loop, tab visible again | resumes |
| after `stop()` | 0 |
| `muted: true`, visible | 0 |

Absolute counts are low because Chrome throttles timers in an unfocused window; the comparison is the result.

## Version

Intentionally **no version bump**: this and #3 would both touch the same seven sync points and conflict. Bump once to 2.8.0 with a combined CHANGELOG entry after both land.