### PR TITLE
chore: use arrow functions in FoleyHandle interface

### DIFF
--- a/packages/react/src/index.d.ts
+++ b/packages/react/src/index.d.ts
@@ -1,14 +1,16 @@
 import type { CueName, Settings, PlayOptions, PlayEvent } from "@foleyjs/core";
 
+type OnFn = ((event: "play", cb: (e: PlayEvent) => void) => () => void) &
+  ((event: "unlock", cb: () => void) => () => void);
+
 export interface FoleyHandle {
-  play(name: CueName, opts?: PlayOptions): void;
-  set(opts: Partial<Settings>): void;
-  get(): Settings;
-  toWav(name: CueName): Promise<Blob>;
-  toBuffer(name: CueName): Promise<AudioBuffer>;
-  on(event: "play", cb: (e: PlayEvent) => void): () => void;
-  on(event: "unlock", cb: () => void): () => void;
-  bind(root?: ParentNode): void;
+  play: (name: CueName, opts?: PlayOptions) => void;
+  set: (opts: Partial<Settings>) => void;
+  get: () => Settings;
+  toWav: (name: CueName) => Promise<Blob>;
+  toBuffer: (name: CueName) => Promise<AudioBuffer>;
+  on: OnFn;
+  bind: (root?: ParentNode) => void;
 }
 
 /** Wires data-foley-* attributes on mount and applies initial settings. */


### PR DESCRIPTION
Thanks for this awesome package, planning to add it everywhere our CTO allows me to!

## Description

I noticed that in React/TS projects with certain eslint rules (specifically the [typescript/unbound-method rule](https://oxc.rs/docs/guide/usage/linter/rules/typescript/unbound-method.html#typescript-unbound-method-oxlint)), there is an error associated with the functions and possible lost `this` scope.

Checking the type definition of the `FoleyHandle` interface in the react package, I noticed that every function was defined as a named function declaration. They handle the `this` scope a bit differently than arrow functions, hence the lint error.

I checked if the actual code of `@foley/core` is using the `this` scope in any of the functions. Since they are not, the `this` binding is irrelevant.
Defining the types then as arrow functions tells TypeScript (and the linter) that these functions are saved to be detached, destructured etc.

## Runtime Implications

This does not have any runtime implications, as the functions don't use `this` in their execution.
