### PR TITLE
Typecheck the published types in CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ numbers matching reality). Read the failure message; it says what to do.
 
 ```sh
 npm install   # once - tests import the framework packages
-npm test      # 61 tests, plain node --test, no framework
+npm test      # plain node --test, no framework (one of them shells out to tsc)
 npm run demo  # serve the demo locally
 ```
 
@@ -18,6 +18,11 @@ npm run demo  # serve the demo locally
 
 - `src/foley.js` - the entire engine, one ES module. Cues are data (`CUES` specs).
 - `src/foley.d.ts` - types, hand-maintained, sync-tested against the module.
+- `types/consumer.ts` - the fixture `npm test` compiles with `tsc --strict` to
+  prove the published types work. Its `@ts-expect-error` lines must keep
+  erroring, so widening anything to `any` fails the build. Write interface
+  members as properties (`stop: () => void`), never method shorthand - the
+  method form makes `const { stop } = play(...)` trip unbound-method lint rules.
 - `index.html` - the demo. CSS in `<head>`, all page logic in ONE
   `<script type="module">` (the standalone build depends on this - see
   `scripts/build-standalone.mjs`). localStorage only between the

--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ playSpec(mySound);
 const wav = await toWavSpec(mySound);
 ```
 
+In TypeScript, narrow on `kind` before touching a layer's fields — `Spec` is a union,
+and cluster layers carry `fMin`/`fMax` where tone and noise layers carry `f`:
+
+```ts
+const layer = mySound[2];
+if (layer.kind === "tone") layer.f = 880;
+```
+
 Or use the visual [Cue Designer on the demo](https://usefoley.dev/#designer) — edit with live playback, then export .wav/.json or share the design as a link.
 
 ## Sound sets

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
       "devDependencies": {
         "@foleyjs/core": "file:.",
         "marked": "^18.0.7",
-        "react": "^18.3.0"
+        "react": "^18.3.0",
+        "typescript": "^5.6.0"
       }
     },
     "node_modules/@foleyjs/core": {
@@ -63,6 +64,20 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@foleyjs/core",
   "version": "2.8.0",
-  "description": "Sound effects for the interface, performed live. 28 interaction cues synthesized with Web Audio \u2014 zero dependencies, zero audio files.",
+  "description": "Sound effects for the interface, performed live. 28 interaction cues synthesized with Web Audio — zero dependencies, zero audio files.",
   "type": "module",
   "main": "./src/foley.js",
   "module": "./src/foley.js",
@@ -52,6 +52,7 @@
   "devDependencies": {
     "@foleyjs/core": "file:.",
     "marked": "^18.0.7",
-    "react": "^18.3.0"
+    "react": "^18.3.0",
+    "typescript": "^5.6.0"
   }
 }

--- a/src/foley.d.ts
+++ b/src/foley.d.ts
@@ -48,8 +48,10 @@ export interface SoundSet {
 }
 
 export interface PlayHandle {
-  /** Fade this performance out (~20ms) and, if looping, stop the loop. */
-  stop(): void;
+  /** Fade this performance out (~20ms) and, if looping, stop the loop.
+      A property, not a method: `const { stop } = play(...)` is a supported
+      pattern, and method syntax makes TypeScript's unbound-method rule object. */
+  stop: () => void;
 }
 
 export interface Settings {

--- a/test/types.test.mjs
+++ b/test/types.test.mjs
@@ -1,0 +1,66 @@
+/* The published type surface is a product, and until now nothing checked it: the
+   other guards assert declarations *exist* (by grepping the d.ts), never that they
+   are correct. A contributor had to report a type problem that CI could not see.
+
+   Two layers here, because they catch different failures:
+   - tsc over test/types/consumer.ts proves the types work for real usage, and that
+     the @ts-expect-error negatives still error (a d.ts of `any` would pass otherwise).
+   - the shape guard below catches the regression tsc CANNOT see: method-shorthand
+     signatures compile identically to property signatures, but only the property
+     form is safe to detach under typescript-eslint's unbound-method rule. */
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const DTS = [
+  "src/foley.d.ts",
+  "packages/react/src/index.d.ts",
+  "packages/vue/src/index.d.ts",
+];
+
+test("the type definitions compile, and every @ts-expect-error still errors", () => {
+  const tsc = join(root, "node_modules", ".bin", "tsc");
+  try {
+    execFileSync(tsc, [
+      "--noEmit", "--strict",
+      "--moduleResolution", "bundler", "--module", "esnext",
+      "--target", "es2022", "--lib", "es2022,dom",
+      join(root, "types", "consumer.ts"),   /* outside test/, which node --test walks */
+    ], { encoding: "utf8", stdio: "pipe" });
+  } catch (e) {
+    assert.fail("tsc rejected the public types:\n" + (e.stdout || "") + (e.stderr || ""));
+  }
+});
+
+test("no d.ts interface uses method shorthand - it breaks destructuring", () => {
+  /* `stop(): void` and `stop: () => void` compile the same, but the first tells
+     TypeScript the member may depend on `this`, so unbound-method fires on
+     `const { stop } = play(...)` - a pattern the README documents. Reported by
+     a contributor in PR #6; this is the guard that keeps it fixed. */
+  for (const file of DTS) {
+    const dts = readFileSync(join(root, file), "utf8");
+    for (const m of dts.matchAll(/export interface (\w+) \{([\s\S]*?)\n\}/g)) {
+      for (const line of m[2].split("\n")) {
+        const method = line.match(/^\s{2,}(\w+)\??\s*\(/);
+        assert.ok(!method,
+          `${file}: ${m[1]}.${method ? method[1] : ""} uses method shorthand; ` +
+          `write it as \`${method ? method[1] : "name"}: (...) => T\` so it can be detached`);
+      }
+    }
+  }
+});
+
+test("every d.ts that ships is covered by the compile check", () => {
+  /* enumerate reality: a new package's d.ts must be added to DTS above */
+  const found = ["src/foley.d.ts"];
+  for (const pkg of readdirSync(join(root, "packages"))) {
+    found.push(`packages/${pkg}/src/index.d.ts`);
+  }
+  assert.deepEqual(found.sort(), [...DTS].sort(),
+    "a d.ts exists that these type guards do not cover");
+});

--- a/types/consumer.ts
+++ b/types/consumer.ts
@@ -1,0 +1,92 @@
+/* Compiled by test/types.test.mjs with `tsc --noEmit --strict`. Two jobs:
+
+   1. Real usage must compile — including detaching every member, since
+      `const { play } = useFoley()` is the documented pattern.
+   2. Every `@ts-expect-error` must ACTUALLY error. tsc fails the build if one
+      of them stops erroring, which is what keeps the types from going vacuous:
+      a d.ts full of `any` would pass job 1 alone. */
+
+import { play, set, get, on, bind, panFor, getSpec, playSpec, toWav, toSprite } from "../src/foley.js";
+import { useFoley } from "../packages/react/src/index.js";
+
+/* ---------- detaching: the pattern unbound-method complains about ---------- */
+
+const foley = useFoley({ volume: 0.7 });
+const { play: p, set: s, get: g, on: o, bind: b, toWav: w } = foley;
+p("success");
+s({ muted: true });
+const settings = g();
+b();
+void w;
+const unsub = o("play", (e) => { const n: string = e.name; void n; });
+unsub();
+o("unlock", () => {})();
+
+/* passed around as bare references, never called as methods */
+function callLater(fn: (name: "tick") => void): void { fn("tick"); }
+callLater(p);
+
+const handle = play("loading", { loop: true });
+if (handle) {
+  const { stop } = handle;   /* PlayHandle.stop must detach too */
+  stop();
+}
+
+/* ---------- the surface, used the way the README documents it ---------- */
+
+const vol: number = settings.volume;
+const loc: number = settings.localize;
+void vol; void loc;
+
+play("tick", { pitch: 4, volume: 0.3, pan: -0.7 });
+play("ping", { pos: [1, 0, -0.5] });
+set({ localize: 0.6, duck: 0.3, theme: "glass" });
+set({ theme: { name: "Acme", transform: { pitch: 0.9 }, cues: { success: getSpec("success") } } });
+bind(document);
+const pan: number = panFor(document.body);
+void pan;
+
+const spec = getSpec("success");
+/* Spec is a union of layer kinds, so TS wants a narrow before touching `f` -
+   cluster layers have fMin/fMax instead. The README says so for this reason. */
+const first = spec[0];
+if (first.kind === "tone") first.f = 880;
+spec.push({ kind: "noise", at: 0.2, filter: "highpass", f: 6000, f2: null,
+            glide: 0.1, q: 1, a: 0.01, d: 0.2, peak: 0.05, send: 0.4 });
+playSpec(spec, { id: "custom", pan: 0.5 });
+
+// @ts-expect-error `f` is not on every layer kind - narrow on `kind` first
+spec[0].f = 880;
+
+async function exports_(): Promise<void> {
+  const blob: Blob = await toWav("chime");
+  const sprite = await toSprite(0.05);
+  const start: number = sprite.map.tick.start;
+  void blob; void start;
+}
+void exports_;
+
+/* ---------- negatives: each of these MUST error ---------- */
+
+// @ts-expect-error unknown cue name
+play("not-a-cue");
+// @ts-expect-error the React handle must be as strict as the core, not widened
+p("not-a-cue");
+// @ts-expect-error ...including its overloaded on()
+o("bogus", () => {});
+// @ts-expect-error ...and its settings
+s({ loudness: 1 });
+// @ts-expect-error unknown event name
+on("bogus", () => {});
+// @ts-expect-error PlayEvent.name is a string, not a number
+on("play", (e) => { const x: number = e.name; void x; });
+// @ts-expect-error pos is a 3-tuple
+play("ping", { pos: [1, 0] });
+// @ts-expect-error unknown theme name
+set({ theme: "vaporwave" });
+// @ts-expect-error unknown setting
+set({ loudness: 1 });
+// @ts-expect-error panFor takes an element
+panFor("#id");
+// @ts-expect-error layer kind is a fixed union
+playSpec([{ kind: "bogus" }]);


### PR DESCRIPTION
Follow-up to #6. That PR fixed a real type defect — and the more interesting fact is that **this repo could not have caught it.**

Every existing type guard greps the d.ts to assert declarations *exist*. None of them check the types are *correct*, and `typescript` wasn't even installed, so I had to run `tsc` by hand to review the contribution. That's the gap this closes.

## Two guards, because they catch different failures

**1. `tsc --strict` over `types/consumer.ts`.** A fixture that uses the public API the way the README documents, including destructuring and detaching every member. Its `@ts-expect-error` lines must keep erroring — so widening anything to `any` *fails the build*. A compile check alone would pass a d.ts made entirely of `any`; this is what stops that.

**2. A shape guard forbidding method shorthand in any d.ts interface.** `tsc` cannot see this one: `stop(): void` and `stop: () => void` compile identically. Only the property form is safe to detach under `unbound-method`. Without this guard, #6 silently reverts the first time someone "tidies" the interface.

## Both were mutation-tested

A guard that cannot fail is theater, so I broke things on purpose:

| mutation | result |
|---|---|
| restore `stop(): void` | shape guard fails, names the member and the fix |
| widen React `play` to `any` | compile guard fails: `Unused '@ts-expect-error' directive` |

The second mutation **initially passed** — which exposed that my fixture only exercised the core `play`, not the React handle's. Fixed by adding negatives against the destructured handle. Worth stating plainly: the mutation test caught a hole in the test.

## Also in here

- **`PlayHandle.stop` had the identical problem** one package over. `const { stop } = play("loading", { loop: true })` is a supported pattern; same fix applied.
- **The fixture found a docs bug on its first run.** The README's `mySound[2].f = 880` doesn't compile — `Spec` is a union and cluster layers carry `fMin`/`fMax`. Added the narrowing pattern to the README rather than loosening the types, since the union is correct and the alternative is worse.

## Notes

- `typescript` is a devDependency only; `files` is still `["src", "README.md", "LICENSE"]`, so nothing new ships.
- The fixture lives in `types/`, not `test/` — `node --test` walks `test/` and tried to execute it.
- No workflow changes: the guards are ordinary `node --test` tests, so they run in CI, locally, and in the pre-release gate automatically.
- 87 tests green.

## Version

No bump here. `stop` changing from method to property is a real change to published types, so this and #6 together want a **2.8.1** patch once both land.